### PR TITLE
Upgrade to 23.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1701071203,
-        "narHash": "sha256-lQywA7QU/vzTdZ1apI0PfgCWNyQobXUYghVrR5zuIeM=",
+        "lastModified": 1701609479,
+        "narHash": "sha256-mcEnMz7XB3K57ZX16VXoEkswljSNGXdMuUu5+g8a8R8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "db1878f013b52ba5e4034db7c1b63e8d04173a86",
+        "rev": "e504e8d01f950776c3a3160ba38c5957a1b89e66",
         "type": "github"
       },
       "original": {
@@ -27,16 +27,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1700392168,
-        "narHash": "sha256-v5LprEFx3u4+1vmds9K0/i7sHjT0IYGs7u9v54iz/OA=",
+        "lastModified": 1700814205,
+        "narHash": "sha256-lWqDPKHRbQfi+zNIivf031BUeyciVOtwCwTjyrhDB5g=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "28535c3a34d79071f2ccb68671971ce0c0984d7e",
+        "rev": "aeb2232d7a32530d3448318790534d196bf9427a",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-23.05",
+        "ref": "release-23.11",
         "repo": "home-manager",
         "type": "github"
       }
@@ -59,11 +59,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1701263465,
-        "narHash": "sha256-lNXUIlkfyDyp9Ox21hr+wsEf/IBklLvb6bYcyeXbdRc=",
+        "lastModified": 1701389149,
+        "narHash": "sha256-rU1suTIEd5DGCaAXKW6yHoCfR1mnYjOXQFOaH7M23js=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "50aa30a13c4ab5e7ba282da460a3e3d44e9d0eb3",
+        "rev": "5de0b32be6e85dc1a9404c75131316e4ffbc634c",
         "type": "github"
       },
       "original": {
@@ -75,11 +75,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1700905716,
-        "narHash": "sha256-w1vHn2MbGfdC+CrP3xLZ3scsI06N0iQLU7eTHIVEFGw=",
+        "lastModified": 1701568804,
+        "narHash": "sha256-iwr1fjOCvlirVL/xNvOTwY9kg3L/F3TC/7yh/QszaPI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dfb95385d21475da10b63da74ae96d89ab352431",
+        "rev": "dc01248a9c946953ad4d438b0a626f5c987a93e4",
         "type": "github"
       },
       "original": {
@@ -146,11 +146,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1701127353,
-        "narHash": "sha256-qVNX0wOl0b7+I35aRu78xUphOyELh+mtUp1KBx89K1Q=",
+        "lastModified": 1701572436,
+        "narHash": "sha256-0anfOQqDend6kSuF8CmOSAZsiAS1nwOsin5VQukh6Q4=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "b1edbf5c0464b4cced90a3ba6f999e671f0af631",
+        "rev": "8bca48cb9a12bbd8766f359ad00336924e91b7f7",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -27,16 +27,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1700814205,
-        "narHash": "sha256-lWqDPKHRbQfi+zNIivf031BUeyciVOtwCwTjyrhDB5g=",
+        "lastModified": 1700392168,
+        "narHash": "sha256-v5LprEFx3u4+1vmds9K0/i7sHjT0IYGs7u9v54iz/OA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "aeb2232d7a32530d3448318790534d196bf9427a",
+        "rev": "28535c3a34d79071f2ccb68671971ce0c0984d7e",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-23.11",
+        "ref": "release-23.05",
         "repo": "home-manager",
         "type": "github"
       }
@@ -114,11 +114,11 @@
     },
     "private-nixpkgs": {
       "locked": {
-        "lastModified": 1698261293,
-        "narHash": "sha256-T4ObDxOOwHD8Y8QCcmg37PvnOJTyCin9Xq2dtGXxGAQ=",
+        "lastModified": 1701431857,
+        "narHash": "sha256-cLqZwoBYEMisx2OslajODSkMett8If6QNyRjAFluxHk=",
         "owner": "rahoni",
         "repo": "nixpkgs",
-        "rev": "432508c7bc0ae9875ff13af6fee032cb7e084f00",
+        "rev": "3bac0da910f542cf331e0e8d87904a63f051f23b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,13 +1,13 @@
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    nixpkgs-stable.url = "github:NixOS/nixpkgs/nixos-23.05";
+    nixpkgs-stable.url = "github:NixOS/nixpkgs/nixos-23.11";
     home-manager = {
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     home-manager-stable = {
-      url = "github:nix-community/home-manager/release-23.05";
+      url = "github:nix-community/home-manager/release-23.11";
       inputs.nixpkgs.follows = "nixpkgs-stable";
     };
     plasma-manager.url = "github:pjones/plasma-manager";

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,10 @@
       "https://nix-community.cachix.org"
       "https://cache.garnix.io"
     ];
+    extra-trusted-substituters = [
+      "https://nix-community.cachix.org"
+      "https://cache.garnix.io"
+    ];
     extra-trusted-public-keys = [
       "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
       "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g="

--- a/flake.nix
+++ b/flake.nix
@@ -58,7 +58,7 @@
         specialArgs = inputs;
         modules = [
           ./surface-raoul-nixos/configuration.nix
-          ./generic/default.nix
+          ./generic
           ./generic/nebula.nix
           home-manager-stable.nixosModules.home-manager
           {
@@ -80,7 +80,7 @@
         specialArgs = inputs;
         modules = [
           ./r-desktop/configuration.nix
-          ./generic/default.nix
+          ./generic
           #./generic/nebula.nix
           home-manager-stable.nixosModules.home-manager
           {

--- a/generic/default.nix
+++ b/generic/default.nix
@@ -25,9 +25,9 @@
   time.timeZone = "Europe/Berlin";
 
   fonts = {
-    enableDefaultFonts = true;
+    enableDefaultPackages = true;
 
-    fonts = with pkgs; [
+    packages = with pkgs; [
       (nerdfonts.override { fonts = [ "Meslo" ]; })
     ];
 

--- a/generic/users/raoul/home-manager.nix
+++ b/generic/users/raoul/home-manager.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, lib, home-manager-stable, plasma-manager, ... }:
+{ config, pkgs, lib, home-manager-stable, ... }:
 with lib;
 {
   imports = [ ./../default.nix ./plasma.nix ];

--- a/r-desktop/configuration.nix
+++ b/r-desktop/configuration.nix
@@ -81,10 +81,6 @@
   # Needed for yubikey ccid Functionality
   services.pcscd.enable = true;
 
-  # Allow unfree packages
-  nixpkgs.pkgs = pkgs;
-  nixpkgs.config.allowUnfree = true;
-
   # List packages installed in system profile. To search, run:
   # $ nix search wget
   environment.systemPackages = with pkgs; [

--- a/surface-raoul-nixos/configuration.nix
+++ b/surface-raoul-nixos/configuration.nix
@@ -90,15 +90,6 @@ in
   # Needed for yubikey ccid Functionality
   services.pcscd.enable = true;
 
-
-  # Enable touchpad support (enabled default in most desktopManager).
-  # services.xserver.libinput.enable = true;
-
-
-  # Allow unfree packages
-  nixpkgs.pkgs = pkgs;
-  nixpkgs.config.allowUnfree = true;
-
   # List packages installed in system profile. To search, run:
   # $ nix search wget
   environment.systemPackages = with pkgs; [

--- a/surface-raoul-nixos/configuration.nix
+++ b/surface-raoul-nixos/configuration.nix
@@ -3,10 +3,6 @@
 # and in the NixOS manual (accessible by running ‘nixos-help’).
 
 { config, pkgs, options, ... }:
-let
-  #home-manager = builtins.fetchTarball "https://github.com/nix-community/home-manager/archive/master.tar.gz";
-  inherit (builtins) concatStringsSep;
-in
 {
   imports =
     [
@@ -142,6 +138,3 @@ in
   system.stateVersion = "23.05"; # Did you read the comment?
 
 }
-
-
-


### PR DESCRIPTION
- flake.lock: Update
- Removed configuration of nixpkgs for upgrade
- Switch stable to 23.11
- Fix renames in fonts config
- flake.lock: Update
- Added nix-community and sops-nix substituters to trusted substituters
- Remove unneeded default.nix and other crap
