### PR TITLE
server: Add a cache folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Install
+
+## Server
+
+Limit the size of /tmp and /var/cache via 
+
+'''
+btrfs qgroup limit 30G /btrfs/tmp
+btrfs qgroup limit 30G /btrfs/cache
+'''

--- a/server/disko.nix
+++ b/server/disko.nix
@@ -29,6 +29,9 @@ in
               type = "btrfs";
               extraArgs = [ "-f" ];
               subvolumes = {
+                "/" = {
+                  mountpoint = "/btrfs";
+                };
                 "/nix" = {
                   mountpoint = "/nix";
                   mountOptions = [
@@ -38,6 +41,9 @@ in
                 };
                 "/tmp" = {
                   mountpoint = "/tmp";
+                };
+                "/cache" = {
+                  mountpoint = "/var/cache";
                 };
                 "/permament" = {
                   mountpoint = "/permament";


### PR DESCRIPTION
Since Jellyfin filled /var/cache/Jellyfin/images nextcloud failed to
login.

/var/cache is limited to 30GiB of size
