### PR TITLE
mailserver: delay start of acme-mail.honermann.info by 120 sec

### DIFF
--- a/server/mailserver.nix
+++ b/server/mailserver.nix
@@ -38,6 +38,8 @@
     };
   };
 
+  systemd.services."acme-mail.honermann.info".serviceConfig.ExecStartPre = [ "sleep 120" ];
+
   services.resolved.enable = true;
 
   #networking.wireguard.enable = true;


### PR DESCRIPTION
This might make the mailserver start again after a reboot
