### PR TITLE
pi-hole: Remove Axel Springer blocklist

### DIFF
--- a/server/pi-hole.nix
+++ b/server/pi-hole.nix
@@ -178,7 +178,6 @@ let
         "https://raw.githubusercontent.com/SoftCreatR/fakerando-domains/main/all.txt"
         "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/domains/multi.txt"
         "https://raw.githubusercontent.com/elliotwutingfeng/Inversion-DNSBL-Blocklists/main/Google_hostnames_ABP.txt"
-        "https://raw.githubusercontent.com/autinerd/anti-axelspringer-hosts/master/axelspringer-hosts"
       ];
       comment = "Diverses (Setup)";
     }


### PR DESCRIPTION
Since this also blocks welt.de which is read as a right wing media reference. This list is to agressiv