### PR TITLE
mailserver: Shorten wait for acme to 10 seconds

### DIFF
--- a/server/mailserver.nix
+++ b/server/mailserver.nix
@@ -39,7 +39,7 @@
   };
 
   systemd.services."acme-mail.honermann.info" = {
-    serviceConfig.ExecStartPre = [ "${pkgs.coreutils}/bin/sleep 120" ];
+    serviceConfig.ExecStartPre = [ "${pkgs.coreutils}/bin/sleep 10" ];
     path = [ pkgs.coreutils ];
   };
 


### PR DESCRIPTION
This prevents timeout. I don't know if this helps in any other way with
the startup
