### PR TITLE
Update to 26.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -38,11 +38,11 @@
     "base16-helix": {
       "flake": false,
       "locked": {
-        "lastModified": 1760703920,
-        "narHash": "sha256-m82fGUYns4uHd+ZTdoLX2vlHikzwzdu2s2rYM2bNwzw=",
+        "lastModified": 1776754714,
+        "narHash": "sha256-E3OAK27smtATTmX45uoTSRsVD+Y+ZiVVfgM/tjpbtYg=",
         "owner": "tinted-theming",
         "repo": "base16-helix",
-        "rev": "d646af9b7d14bff08824538164af99d0c521b185",
+        "rev": "4d508123037e7851ad36ebf7d9c48b0e9e1eb581",
         "type": "github"
       },
       "original": {
@@ -137,11 +137,11 @@
     "firefox-gnome-theme": {
       "flake": false,
       "locked": {
-        "lastModified": 1764873433,
-        "narHash": "sha256-1XPewtGMi+9wN9Ispoluxunw/RwozuTRVuuQOmxzt+A=",
+        "lastModified": 1779670703,
+        "narHash": "sha256-UdfMivNMwCCqQsYDg5pSz8X2IOaOrIZLIIy+Bg3CO2o=",
         "owner": "rafaelmardojai",
         "repo": "firefox-gnome-theme",
-        "rev": "f7ffd917ac0d253dbd6a3bf3da06888f57c69f92",
+        "rev": "942159e73e40bf785816f7f1f5feed9ef3d7c8f9",
         "type": "github"
       },
       "original": {
@@ -203,13 +203,13 @@
       "locked": {
         "lastModified": 1767039857,
         "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
-        "owner": "edolstra",
+        "owner": "NixOS",
         "repo": "flake-compat",
         "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
         "type": "github"
       },
       "original": {
-        "owner": "edolstra",
+        "owner": "NixOS",
         "repo": "flake-compat",
         "type": "github"
       }
@@ -243,11 +243,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1768135262,
-        "narHash": "sha256-PVvu7OqHBGWN16zSi6tEmPwwHQ4rLPU9Plvs8/1TUBY=",
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "80daad04eddbbf5a4d883996a73f3f542fa437ac",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
         "type": "github"
       },
       "original": {
@@ -264,11 +264,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1767609335,
-        "narHash": "sha256-feveD98mQpptwrAEggBQKJTYbvwwglSbOv53uCfH9PY=",
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "250481aafeb741edfe23d29195671c19b36b6dca",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
         "type": "github"
       },
       "original": {
@@ -280,24 +280,6 @@
     "flake-utils": {
       "inputs": {
         "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": "systems_3"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -359,11 +341,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772893680,
-        "narHash": "sha256-JDqZMgxUTCq85ObSaFw0HhE+lvdOre1lx9iI6vYyOEs=",
+        "lastModified": 1778507602,
+        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "8baab586afc9c9b57645a734c820e4ac0a604af9",
+        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
         "type": "github"
       },
       "original": {
@@ -477,20 +459,18 @@
     "gnome-shell": {
       "flake": false,
       "locked": {
-        "host": "gitlab.gnome.org",
         "lastModified": 1767737596,
         "narHash": "sha256-eFujfIUQDgWnSJBablOuG+32hCai192yRdrNHTv0a+s=",
         "owner": "GNOME",
         "repo": "gnome-shell",
         "rev": "ef02db02bf0ff342734d525b5767814770d85b49",
-        "type": "gitlab"
+        "type": "github"
       },
       "original": {
-        "host": "gitlab.gnome.org",
         "owner": "GNOME",
-        "ref": "gnome-49",
         "repo": "gnome-shell",
-        "type": "gitlab"
+        "rev": "ef02db02bf0ff342734d525b5767814770d85b49",
+        "type": "github"
       }
     },
     "home-manager": {
@@ -520,16 +500,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1779506708,
-        "narHash": "sha256-QOD/CNm196nCJRheux/URi4/HE66fthdOMqCJoPP1Y0=",
+        "lastModified": 1780361225,
+        "narHash": "sha256-wnV9ttf4fPWNonBIQmvlrSlNpQYgx5HgWWd007mwIFA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3ee51fbdac8c8bdfe1e7e1fcaba6520a563f394f",
+        "rev": "e28654b71096e08c019d4861ca26acb646f583d8",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-25.11",
+        "ref": "release-26.05",
         "repo": "home-manager",
         "type": "github"
       }
@@ -593,34 +573,6 @@
       "original": {
         "owner": "nix-community",
         "repo": "impermanence",
-        "type": "github"
-      }
-    },
-    "ixx": {
-      "inputs": {
-        "flake-utils": [
-          "nixvim-stable",
-          "nuschtosSearch",
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "nixvim-stable",
-          "nuschtosSearch",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1754860581,
-        "narHash": "sha256-EM0IE63OHxXCOpDHXaTyHIOk2cNvMCGPqLt/IdtVxgk=",
-        "owner": "NuschtOS",
-        "repo": "ixx",
-        "rev": "babfe85a876162c4acc9ab6fb4483df88fa1f281",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NuschtOS",
-        "ref": "v0.1.1",
-        "repo": "ixx",
         "type": "github"
       }
     },
@@ -814,16 +766,16 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1779796641,
-        "narHash": "sha256-ZsIrKmhp4vbBXoXXmR/tBXA/UCsAQiJL9vsgZEduhVY=",
+        "lastModified": 1780453794,
+        "narHash": "sha256-bXMRa9VTsHSPXL4Cw8R6JJLQeY3Y/IP4+YJCYVmQ7FY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "25f538306313eae3927264466c70d7001dcea1df",
+        "rev": "6b316287bae2ee04c9b93c8c858d930fd07d7338",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -875,6 +827,38 @@
     },
     "nixpkgs_5": {
       "locked": {
+        "lastModified": 1780365719,
+        "narHash": "sha256-QfWfccTN+70ZQ4m2qlU9PiKfz2Yppq94058iJyARNwc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ffa10e26ae11d676b2db836259889f1f571cb14f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_6": {
+      "locked": {
+        "lastModified": 1780203844,
+        "narHash": "sha256-K5sT4jTpGs15ADhviMKNBH38REpPf5Q6mM1+N6cArVE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b51242d7d43689db2f3be91bd05d5b24fbb469c4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-26.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_7": {
+      "locked": {
         "lastModified": 1770073757,
         "narHash": "sha256-Vy+G+F+3E/Tl+GMNgiHl9Pah2DgShmIUBJXmbiQPHbI=",
         "owner": "NixOS",
@@ -892,9 +876,7 @@
     "nixvim": {
       "inputs": {
         "flake-parts": "flake-parts",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
+        "nixpkgs": "nixpkgs_5",
         "systems": "systems_2"
       },
       "locked": {
@@ -914,23 +896,20 @@
     "nixvim-stable": {
       "inputs": {
         "flake-parts": "flake-parts_2",
-        "nixpkgs": [
-          "nixpkgs-stable"
-        ],
-        "nuschtosSearch": "nuschtosSearch",
-        "systems": "systems_4"
+        "nixpkgs": "nixpkgs_6",
+        "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1780080801,
-        "narHash": "sha256-p+PENiIqFmE/ybT+Rrmp61441u0SQkQKvJIVfctHD/E=",
+        "lastModified": 1780214453,
+        "narHash": "sha256-Bfq9y0X6Vs4UPb67u7hN3jt7fJKHtl3+g0lBSDebRNg=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "0d4ae8bb156799094d2e5c81cbcacf99f07b634c",
+        "rev": "167da56c3ab1e51751a6ae4a997ed66587f9edae",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixvim",
         "type": "github"
       }
@@ -947,39 +926,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1767886815,
-        "narHash": "sha256-pB2BBv6X9cVGydEV/9Y8+uGCvuYJAlsprs1v1QHjccA=",
+        "lastModified": 1779766384,
+        "narHash": "sha256-P7Ohnlq8b8b2fU+Sgkrej7LBTM60LBTkHleLuYzmLmU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4ff84374d77ff62e2e13a46c33bfeb73590f9fef",
+        "rev": "57800b7ab648725ccd33551d01484ee14952ad3f",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
         "repo": "NUR",
-        "type": "github"
-      }
-    },
-    "nuschtosSearch": {
-      "inputs": {
-        "flake-utils": "flake-utils_2",
-        "ixx": "ixx",
-        "nixpkgs": [
-          "nixvim-stable",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1768249818,
-        "narHash": "sha256-ANfn5OqIxq3HONPIXZ6zuI5sLzX1sS+2qcf/Pa0kQEc=",
-        "owner": "NuschtOS",
-        "repo": "search",
-        "rev": "b6f77b88e9009bfde28e2130e218e5123dc66796",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NuschtOS",
-        "repo": "search",
         "type": "github"
       }
     },
@@ -1056,7 +1012,7 @@
       "inputs": {
         "flake-compat": "flake-compat_3",
         "gitignore": "gitignore_3",
-        "nixpkgs": "nixpkgs_5"
+        "nixpkgs": "nixpkgs_7"
       },
       "locked": {
         "lastModified": 1778507602,
@@ -1120,7 +1076,7 @@
         "sops-nix": "sops-nix",
         "streamdeck-obs": "streamdeck-obs",
         "stylix": "stylix",
-        "systems": "systems_6"
+        "systems": "systems_5"
       }
     },
     "rust-overlay": {
@@ -1175,16 +1131,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1773912645,
-        "narHash": "sha256-QHzRqq6gh+t3F/QU9DkP7X63dDDcuIQmaDz12p7ANTg=",
+        "lastModified": 1779651513,
+        "narHash": "sha256-lUmq8sXQzihreq9UMqAkSBy9z9ueZbRnFyltzYVfQ2I=",
         "owner": "simple-nixos-mailserver",
         "repo": "nixos-mailserver",
-        "rev": "25e6dbb8fca3b6e779c5a46fd03bd760b2165bb5",
+        "rev": "6c11ff592ef0dce8f1cc2fd870a6d61bd9133afa",
         "type": "gitlab"
       },
       "original": {
         "owner": "simple-nixos-mailserver",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixos-mailserver",
         "type": "gitlab"
       }
@@ -1242,24 +1198,23 @@
           "nixpkgs-stable"
         ],
         "nur": "nur",
-        "systems": "systems_5",
-        "tinted-foot": "tinted-foot",
+        "systems": "systems_4",
         "tinted-kitty": "tinted-kitty",
         "tinted-schemes": "tinted-schemes",
         "tinted-tmux": "tinted-tmux",
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1780418491,
-        "narHash": "sha256-+eo3U9WHpCkaT/FBGf98kdQprKMUREdY/vmvkej5EiI=",
+        "lastModified": 1780585491,
+        "narHash": "sha256-tv0CPeo5GxMl8d1jHGsCJGTsz6CGFwluIfpm7V30APs=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "16689b1d3280604a16d29e249f6b5a1a688e3905",
+        "rev": "aacc65706d523528aed81f55c2c780aaeb541d55",
         "type": "github"
       },
       "original": {
         "owner": "danth",
-        "ref": "release-25.11",
+        "ref": "release-26.05",
         "repo": "stylix",
         "type": "github"
       }
@@ -1335,40 +1290,8 @@
         "type": "github"
       },
       "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_6": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
         "id": "systems",
         "type": "indirect"
-      }
-    },
-    "tinted-foot": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1726913040,
-        "narHash": "sha256-+eDZPkw7efMNUf3/Pv0EmsidqdwNJ1TaOum6k7lngDQ=",
-        "owner": "tinted-theming",
-        "repo": "tinted-foot",
-        "rev": "fd1b924b6c45c3e4465e8a849e67ea82933fcbe4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "tinted-theming",
-        "repo": "tinted-foot",
-        "rev": "fd1b924b6c45c3e4465e8a849e67ea82933fcbe4",
-        "type": "github"
       }
     },
     "tinted-kitty": {
@@ -1390,11 +1313,11 @@
     "tinted-schemes": {
       "flake": false,
       "locked": {
-        "lastModified": 1767817087,
-        "narHash": "sha256-eGE8OYoK6HzhJt/7bOiNV2cx01IdIrHL7gXgjkHRdNo=",
+        "lastModified": 1777806186,
+        "narHash": "sha256-PDF0/wObw4nIsSBeXVYLsloXOiphXCgIdsrNcVXguKs=",
         "owner": "tinted-theming",
         "repo": "schemes",
-        "rev": "bd99656235aab343e3d597bf196df9bc67429507",
+        "rev": "0c94645546f4f3ddac77a1a5fce54eb95bf50795",
         "type": "github"
       },
       "original": {
@@ -1406,11 +1329,11 @@
     "tinted-tmux": {
       "flake": false,
       "locked": {
-        "lastModified": 1767489635,
-        "narHash": "sha256-e6nnFnWXKBCJjCv4QG4bbcouJ6y3yeT70V9MofL32lU=",
+        "lastModified": 1778379944,
+        "narHash": "sha256-wPDFzMGSlARlw0Sfsn48Q2+jPSfk6N0Ng6BC/d+7Q24=",
         "owner": "tinted-theming",
         "repo": "tinted-tmux",
-        "rev": "3c32729ccae99be44fe8a125d20be06f8d7d8184",
+        "rev": "fe0203a198690e71a5ff11e08812a4673de3678d",
         "type": "github"
       },
       "original": {
@@ -1422,11 +1345,11 @@
     "tinted-zed": {
       "flake": false,
       "locked": {
-        "lastModified": 1767488740,
-        "narHash": "sha256-wVOj0qyil8m+ouSsVZcNjl5ZR+1GdOOAooAatQXHbuU=",
+        "lastModified": 1778378178,
+        "narHash": "sha256-OXPXRIQgGwV77HjYRryOHguh4ALX96jkg+tseLkGgHA=",
         "owner": "tinted-theming",
         "repo": "base16-zed",
-        "rev": "11abb0b282ad3786a2aae088d3a01c60916f2e40",
+        "rev": "9cd816033ff969415b190722cddf134e78a5665f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   inputs = {
     self.submodules = true;
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    nixpkgs-stable.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs-stable.url = "github:NixOS/nixpkgs/nixos-26.05";
     nixpkgs-master.url = "github:NixOS/nixpkgs";
 
     disko = {
@@ -18,7 +18,7 @@
     };
 
     home-manager-stable = {
-      url = "github:nix-community/home-manager/release-25.11";
+      url = "github:nix-community/home-manager/release-26.05";
       inputs.nixpkgs.follows = "nixpkgs-stable";
     };
 
@@ -50,12 +50,10 @@
 
     nixvim = {
       url = "github:nix-community/nixvim";
-      inputs.nixpkgs.follows = "nixpkgs";
     };
 
     nixvim-stable = {
-      url = "github:nix-community/nixvim/nixos-25.11";
-      inputs.nixpkgs.follows = "nixpkgs-stable";
+      url = "github:nix-community/nixvim/nixos-26.05";
     };
 
     plasma-manager = {
@@ -77,7 +75,7 @@
     pre-commit-hooks.url = "github:cachix/git-hooks.nix";
 
     simple-mail-server = {
-      url = "gitlab:simple-nixos-mailserver/nixos-mailserver/nixos-25.11";
+      url = "gitlab:simple-nixos-mailserver/nixos-mailserver/nixos-26.05";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
@@ -92,7 +90,7 @@
     };
 
     stylix = {
-      url = "github:danth/stylix/release-25.11";
+      url = "github:danth/stylix/release-26.05";
       inputs.nixpkgs.follows = "nixpkgs-stable";
     };
   };

--- a/generic/neovim.nix
+++ b/generic/neovim.nix
@@ -16,6 +16,7 @@ in
     vimdiffAlias = true;
     vimAlias = true;
     viAlias = true;
+    nixpkgs.config.allowUnfree = true;
 
     #set colorscheme
     colorschemes.gruvbox = {

--- a/generic/users/raoul/home-manager.nix
+++ b/generic/users/raoul/home-manager.nix
@@ -54,7 +54,6 @@ with lib;
     firefox = {
       enable = true;
       nativeMessagingHosts = with pkgs; [
-        vdhcoapp
         keepassxc
         kdePackages.plasma-browser-integration
       ];

--- a/generic/users/raoul/home-manager.nix
+++ b/generic/users/raoul/home-manager.nix
@@ -53,6 +53,7 @@ with lib;
 
     firefox = {
       enable = true;
+      configPath = "${config.xdg.configHome}/mozilla/firefox";
       nativeMessagingHosts = with pkgs; [
         keepassxc
         kdePackages.plasma-browser-integration

--- a/generic/users/raoul/home-manager.nix
+++ b/generic/users/raoul/home-manager.nix
@@ -30,7 +30,7 @@ with lib;
     })
     (makeAutostartItem {
       name = "com.github.xeco23.WasIstLos";
-      package = wasistlos;
+      package = karere;
     })
     (makeAutostartItem {
       name = "org.keepassxc.KeePassXC";

--- a/generic/users/ssh.nix
+++ b/generic/users/ssh.nix
@@ -6,7 +6,7 @@ in
   programs.ssh = {
     enable = true;
     enableDefaultConfig = false;
-    matchBlocks = rec {
+    settings = rec {
       cat-laptop = {
         user = "cathach";
         identityFile = sshIdentity "support";

--- a/jasmine/users.nix
+++ b/jasmine/users.nix
@@ -16,7 +16,7 @@
       keepassxc
       kdePackages.kmail
       kdePackages.kleopatra
-      wasistlos
+      karere
       ddcutil
       kdePackages.kaddressbook
       yubioath-flutter

--- a/lenovo-linux/configuration.nix
+++ b/lenovo-linux/configuration.nix
@@ -157,7 +157,6 @@
 
       # Multimedia
       audacity
-      kaffeine # libVLC Optionen: Default: --no-video-title-show  Optionale Ergänzungen: -V xcb_xv  oder  -V xcb_glx:w
       vlc # Zielpfad: /run/current-system/sw/share/soundfonts/
       # Bereich vdr
       # rapVdr # Alternative TV-Software zu KAFFEINE (und SERVICE)

--- a/lenovo-linux/configuration.nix
+++ b/lenovo-linux/configuration.nix
@@ -203,7 +203,6 @@
       soundconverter
       mpv # mpv Media Player
       smplayer # SM-Player (Video und Ton)
-      vdhcoapp # Für Video DownloadHelper AddOn Firefox
 
       # KDE-Programme
       kdePackages.partitionmanager
@@ -253,7 +252,6 @@
       tvbrowser
       skanlite
       simplescreenrecorder
-      vdhcoapp # Im Anschluss als User den Befehl "vdhcoapp install" ausführen
     ];
 
   # Some programs need SUID wrappers, can be configured further or are

--- a/lenovo-linux/configuration.nix
+++ b/lenovo-linux/configuration.nix
@@ -246,7 +246,7 @@
       nextcloud-client
       digikam
       signal-desktop
-      wasistlos
+      karere
       zoom
       mediathekview
       tvbrowser

--- a/r-desktop/configuration.nix
+++ b/r-desktop/configuration.nix
@@ -58,7 +58,6 @@
   programs.noisetorch.enable = true;
 
   services.gvfs.enable = true;
-  programs.adb.enable = true;
 
   # Needed for yubikey ccid Functionality
   services.pcscd.enable = true;

--- a/r-desktop/users.nix
+++ b/r-desktop/users.nix
@@ -30,7 +30,7 @@
       #      jetbrains.pycharm-professional
       nixos-generators
       kdePackages.kleopatra
-      wasistlos
+      karere
       gh
       tetex
       nixpkgs-fmt

--- a/raoul-framework/configuration.nix
+++ b/raoul-framework/configuration.nix
@@ -45,7 +45,6 @@
     qpwgraph
     signal-desktop
     trayscale
-    vdhcoapp
     vlc
     xournalpp
     zsh-completions

--- a/raoul-framework/configuration.nix
+++ b/raoul-framework/configuration.nix
@@ -125,20 +125,20 @@
           libGL
           libappindicator-gtk3
           vulkan-loader
-          xorg.libX11
-          xorg.libXScrnSaver
-          xorg.libXcomposite
-          xorg.libXcursor
-          xorg.libXdamage
-          xorg.libXext
-          xorg.libXfixes
-          xorg.libXi
-          xorg.libXrandr
-          xorg.libXrender
-          xorg.libXtst
-          xorg.libxcb
-          xorg.libxkbfile
-          xorg.libxshmfence
+          libX11
+          libXScrnSaver
+          libXcomposite
+          libXcursor
+          libXdamage
+          libXext
+          libXfixes
+          libXi
+          libXrandr
+          libXrender
+          libXtst
+          libxcb
+          libxkbfile
+          libxshmfence
         ];
     };
     noisetorch.enable = true;

--- a/raoul-framework/configuration.nix
+++ b/raoul-framework/configuration.nix
@@ -236,7 +236,7 @@
         texliveFull # full latex
         touying
         typst
-        wasistlos
+        karere
         yubioath-flutter
       ];
     };

--- a/raoul-framework/configuration.nix
+++ b/raoul-framework/configuration.nix
@@ -72,7 +72,6 @@
   ];
 
   programs = {
-    adb.enable = true;
     ausweisapp = {
       enable = true;
       openFirewall = true;

--- a/rescueIso/configuration.nix
+++ b/rescueIso/configuration.nix
@@ -42,7 +42,10 @@
 
   system.stateVersion = "23.11";
 
-  fileSystems."/".device = "/dev/sda";
+  fileSystems."/" = {
+    device = "/dev/sda";
+    fsType = "ext4";
+  };
   boot.loader.grub.device = "/dev/sda";
   #  lib.isoFileSystems."/persitent" = {
   #    label = "VentoyBTRFS";

--- a/rescueIso/configuration.nix
+++ b/rescueIso/configuration.nix
@@ -46,6 +46,7 @@
     device = "/dev/sda";
     fsType = "ext4";
   };
+  boot.zfs.forceImportRoot = false;
   boot.loader.grub.device = "/dev/sda";
   #  lib.isoFileSystems."/persitent" = {
   #    label = "VentoyBTRFS";

--- a/server/default.nix
+++ b/server/default.nix
@@ -191,7 +191,10 @@ in
     ]; # mode=755 so only root can write to those files
   };
 
-  boot.zfs.extraPools = [ "MainZFS" ];
+  boot.zfs = {
+    extraPools = [ "MainZFS" ];
+    forceImportRoot = false;
+  };
   services.zfs.autoScrub.enable = true;
 
   myModules.autoUpgrade.enable = true;

--- a/server/jellyfin.nix
+++ b/server/jellyfin.nix
@@ -9,7 +9,7 @@ in
     openFirewall = true;
   };
 
-  services.jellyseerr = {
+  services.seerr = {
     enable = true;
     openFirewall = true;
   };

--- a/server/kanidm.nix
+++ b/server/kanidm.nix
@@ -79,18 +79,20 @@ in
 
   services.kanidm = {
     package = pkgs.kanidmWithSecretProvisioning_1_10;
-    server.enable = true;
-    serverSettings = {
-      bindaddress = "0.0.0.0:443";
-      ldapbindaddress = "0.0.0.0:3636";
-      http_client_address_info.x-forward-for = [
-        config.myModules.ips.ssl-proxy.ipv4.address
-      ];
-      version = "2";
-      domain = "account.honermann.info";
-      origin = "https://account.honermann.info";
-      tls_key = "/var/lib/acme/account.honermann.info/key.pem";
-      tls_chain = "/var/lib/acme/account.honermann.info/fullchain.pem";
+    server = {
+      enable = true;
+      settings = {
+        bindaddress = "0.0.0.0:443";
+        ldapbindaddress = "0.0.0.0:3636";
+        http_client_address_info.x-forward-for = [
+          config.myModules.ips.ssl-proxy.ipv4.address
+        ];
+        version = "2";
+        domain = "account.honermann.info";
+        origin = "https://account.honermann.info";
+        tls_key = "/var/lib/acme/account.honermann.info/key.pem";
+        tls_chain = "/var/lib/acme/account.honermann.info/fullchain.pem";
+      };
     };
     provision = {
       enable = true;

--- a/server/kanidm.nix
+++ b/server/kanidm.nix
@@ -79,7 +79,7 @@ in
 
   services.kanidm = {
     package = pkgs.kanidmWithSecretProvisioning_1_10;
-    enableServer = true;
+    server.enable = true;
     serverSettings = {
       bindaddress = "0.0.0.0:443";
       ldapbindaddress = "0.0.0.0:3636";

--- a/server/mailserver.nix
+++ b/server/mailserver.nix
@@ -50,7 +50,7 @@ in
 
   mailserver = {
     enable = true;
-    stateVersion = 3;
+    stateVersion = 5;
     fqdn = "mail.honermann.info";
     domains = [ "honermann.info" ];
     enableSubmission = true; # Enable SMTP with starttls this is discouraged but needed for jellyseer

--- a/server/mailserver.nix
+++ b/server/mailserver.nix
@@ -97,9 +97,8 @@ in
       Persistent = true;
     };
     paths = [
-      mail.mailDirectory
-      mail.sieveDirectory
-      mail.dkimKeyDirectory
+      mail.storage.path
+      mail.dkim.keyDirectory
     ];
     pruneOpts = [
       "--keep-daily 7"

--- a/server/mailserver.nix
+++ b/server/mailserver.nix
@@ -56,13 +56,13 @@ in
     enableSubmission = true; # Enable SMTP with starttls this is discouraged but needed for jellyseer
     enableManageSieve = true;
 
-    extraVirtualAliases = {
+    aliases = {
       "abuse@honermann.info" = [ "raoul@honermann.info" ];
       "postmaster@honermann.info" = "raoul@honermann.info";
     };
 
     # Generate password with 'mkpasswd -m bcrypt'
-    loginAccounts = {
+    accounts = {
       "raoul@honermann.info" = {
         hashedPassword = "$2b$05$XpvYiA47SAxYaFu8OVp7NOGOgpWUxEhis7czLSCE2ZgtVMk4pg9gu";
       };
@@ -83,8 +83,10 @@ in
       };
     };
 
-    certificateFile = "${certPath}/fullchain.pem";
-    keyFile = "${certPath}/key.pem";
+    x509 = {
+      certificateFile = "${certPath}/fullchain.pem";
+      privateKeyFile = "${certPath}/key.pem";
+    };
   };
 
   services.restic.backups.mail = {

--- a/server/mailserver.nix
+++ b/server/mailserver.nix
@@ -83,7 +83,6 @@ in
       };
     };
 
-    certificateScheme = "manual";
     certificateFile = "${certPath}/fullchain.pem";
     keyFile = "${certPath}/key.pem";
   };

--- a/server/music.nix
+++ b/server/music.nix
@@ -62,8 +62,6 @@ in
         "hass_players"
         "jellyfin"
         "theaudiodb"
-        "builtin"
-        "builtin_player"
       ];
     };
     snapserver = {

--- a/sylvia-fujitsu/configuration.nix
+++ b/sylvia-fujitsu/configuration.nix
@@ -101,7 +101,6 @@
 
       # Multimedia
       audacity
-      #kaffeine # libVLC Optionen: Default: --no-video-title-show  Optionale Ergänzungen: -V xcb_xv  oder  -V xcb_glx:w
       vlc # Zielpfad: /run/current-system/sw/share/soundfonts/
       # Bereich vdr
       # rapVdr # Alternative TV-Software zu KAFFEINE (und SERVICE)

--- a/sylvia-fujitsu/configuration.nix
+++ b/sylvia-fujitsu/configuration.nix
@@ -148,7 +148,7 @@
       nextcloud-client
       digikam
       signal-desktop
-      wasistlos
+      karere
       zoom
       mediathekview
       tvbrowser

--- a/sylvia-fujitsu/configuration.nix
+++ b/sylvia-fujitsu/configuration.nix
@@ -130,7 +130,6 @@
       coreutils
       soundconverter
       # mp3splt Unmaintained #TODO: find replacement
-      vdhcoapp # Für Video DownloadHelper AddOn Firefox
 
       # KDE-Programme
       kdePackages.partitionmanager
@@ -155,7 +154,6 @@
       tvbrowser
       skanlite
       simplescreenrecorder
-      vdhcoapp # Im Anschluss als User den Befehl "vdhcoapp install" ausführen
     ];
 
   # List services that you want to enable:


### PR DESCRIPTION
- **sylvia-fujitsu: switch kaffeine to flatpak**
- **nixvim: allowUnfree for nixvim cmp packages**
- **26.05: Remove kaffeine since it is no longer supported**
- **26.05 vdh no longer needs vdhcoapp**
- **26.05: Remove programs.adb**
- **26.05: The xorg packageset was removed**
- **26.05: jellyseerr was renamed to seerr**
- **26.05/kanidm: enableServer was renamed to server.enable**
- **26.05: storage path settings were changed**
- **26.05: wasistlos was removed replace with karere**
- **26.05/musicassistant: builtin_player and builtin were removed**
- **26.05: ssh.matchBlocks renamed to ssh.settings**
- **mailserver: migrate to stateVersion 5**
- **26.05/mailserver: certificateScheme was removed**
- **26.05/mailserver: some settings were renamed**
- **26.05/home-manager: set programs.firefox.configPath**
- **26.05/vps: specify fsType**
- **26.05/zfs: disable zfs forceImportRoot for server and rescueIso**
- **flake: Update to 26.05**
