### PR TITLE
restic: Remove default from pruneOpts

### DIFF
--- a/generic/modules/restic.nix
+++ b/generic/modules/restic.nix
@@ -28,7 +28,7 @@ let
       passwordFile = mkDefault config.sops.secrets.repo-passwd.path;
       environmentFile = mkDefault config.sops.templates.restic-http-conf.path;
       progressFps = mkDefault 0.1;
-      pruneOpts = mkDefault [
+      pruneOpts = [
         "--keep-daily 7"
         "--keep-weekly 4"
         "--keep-monthly 12"


### PR DESCRIPTION
This is needed since otherwise if you want to append something to the
list they get replaced. Overriding the prue ops is possible via mkForce
